### PR TITLE
タスクモデルから受け取った情報をビューに渡す

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -3,17 +3,28 @@
 namespace App\Http\Controllers;
 
 use App\Folder;
+use App\Task; //Taskモデルを読み込む
 use Illuminate\Http\Request;
 
 class TaskController extends Controller
 {
     public function index(int $id)
     {
+        //すべてのフォルダを取得する
         $folders = Folder::all();
-    
+
+        //選択したフォルダを取得する
+        $current_folder = Folder::find($id);
+
+        //選択したフォルダに紐づかれたタスクを取得する
+        $tasks = Task::where('folder_id', $current_folder->id)->get();
+
         return view('tasks/index', [
             'folders' => $folders,
-            'current_folder_id' => $id,
+            //選択したフォルダのIDを受け取り、view関数でテンプレートに渡す
+            'current_folder_id' => $current_folder->id,
+            //選択したフォルダに紐づかれたタスクをview関数でテンプレートに渡す
+            'tasks' => $tasks,
         ]);
     }
 }


### PR DESCRIPTION
タスクモデルを読み込み、選ばれたフォルダごとに情報を取得し、フォルダに基づいたタスクを取得しビューへ渡すため、タスクコントローラーを編集しました。